### PR TITLE
Add missing `optional` wrapper object

### DIFF
--- a/snap/local/runtime-helpers/bin/redis-token-setup.sh
+++ b/snap/local/runtime-helpers/bin/redis-token-setup.sh
@@ -47,16 +47,17 @@ if [ -f "$VAULT_TOKEN_FILE" ] ; then
 	fi
 
 	# process the reponse and check if yq works
-	REDIS_CREDENTIALS=$(echo $BODY| yq '.data')
+	REDIS_CREDENTIALS_USERNAME=$(echo $BODY| yq '.data.username')
+	REDIS_CREDENTIALS_PASSWORD=$(echo $BODY| yq '.data.password')
 	handle_error $? "yq" $REDIS_CREDENTIALS
 
 	# pass generated Redis credentials to configuration files
 	logger "edgex-ekuiper:redis-token-setup: adding Redis credentials to $SOURCE_FILE"
-	YQ_RES=$(yq -i '.default += {"optional":'"$REDIS_CREDENTIALS"'}' "$SOURCE_FILE")
+	YQ_RES=$(yq -i '.default += {"optional":{"Username":"'$REDIS_CREDENTIALS_USERNAME'"}+{"Password":"'$REDIS_CREDENTIALS_PASSWORD'"}}' "$SOURCE_FILE")
 	handle_error $? "yq" $YQ_RES
 	
 	logger "edgex-ekuiper:redis-token-setup: adding Redis credentials to $CONNECTIONS_FILE"
-	YQ_RES=$(yq -i '.edgex.redisMsgBus += '"$REDIS_CREDENTIALS"'' "$CONNECTIONS_FILE")
+	YQ_RES=$(yq -i '.edgex.redisMsgBus += {"optional":{"Username":"'$REDIS_CREDENTIALS_USERNAME'"}+{"Password":"'$REDIS_CREDENTIALS_PASSWORD'"}}' "$CONNECTIONS_FILE")
 	handle_error $? "yq" $YQ_RES
 
 	logger "edgex-ekuiper:redis-token-setup: configured eKuiper to authenticate with Redis, using credentials fetched from Vault"

--- a/snap/local/runtime-helpers/bin/redis-token-setup.sh
+++ b/snap/local/runtime-helpers/bin/redis-token-setup.sh
@@ -47,17 +47,18 @@ if [ -f "$VAULT_TOKEN_FILE" ] ; then
 	fi
 
 	# process the reponse and check if yq works
-	REDIS_CREDENTIALS_USERNAME=$(echo $BODY| yq '.data.username')
-	REDIS_CREDENTIALS_PASSWORD=$(echo $BODY| yq '.data.password')
-	handle_error $? "yq" $REDIS_CREDENTIALS
+	REDIS_USER=$(echo $BODY| yq '.data.username')
+	handle_error $? "yq" $REDIS_USER
+	REDIS_PASS=$(echo $BODY| yq '.data.password')
+	handle_error $? "yq" $REDIS_PASS
 
 	# pass generated Redis credentials to configuration files
 	logger "edgex-ekuiper:redis-token-setup: adding Redis credentials to $SOURCE_FILE"
-	YQ_RES=$(yq -i '.default += {"optional":{"Username":"'$REDIS_CREDENTIALS_USERNAME'"}+{"Password":"'$REDIS_CREDENTIALS_PASSWORD'"}}' "$SOURCE_FILE")
+	YQ_RES=$(yq -i '.default += {"optional":{"Username":"'$REDIS_USER'"}+{"Password":"'$REDIS_PASS'"}}' "$SOURCE_FILE")
 	handle_error $? "yq" $YQ_RES
 	
 	logger "edgex-ekuiper:redis-token-setup: adding Redis credentials to $CONNECTIONS_FILE"
-	YQ_RES=$(yq -i '.edgex.redisMsgBus += {"optional":{"Username":"'$REDIS_CREDENTIALS_USERNAME'"}+{"Password":"'$REDIS_CREDENTIALS_PASSWORD'"}}' "$CONNECTIONS_FILE")
+	YQ_RES=$(yq -i '.edgex.redisMsgBus += {"optional":{"Username":"'$REDIS_USER'"}+{"Password":"'$REDIS_PASS'"}}' "$CONNECTIONS_FILE")
 	handle_error $? "yq" $YQ_RES
 
 	logger "edgex-ekuiper:redis-token-setup: configured eKuiper to authenticate with Redis, using credentials fetched from Vault"


### PR DESCRIPTION
Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

This PR solves the issue: 
`level=error msg="can not create client for connection selector : edgex.redisMsgBus have error map config map to struct map[Password:h/WBn1ZPg/meBjPTkfwQgTYf3vTirJsOzaybjaosVzGE Username:redis5 port:6379 protocol:redis server:localhost type:redis] fail for connection selector edgex.redisMsgBus with error: 1 error(s) decoding:\n\n* '' has invalid keys: Password, Username" file="connection/manager.go:61"`

The reason for this issue is, that the `optional` wrapper object was missing during the process of adding Redis credentials to the connections file.

The solution for this issue is to add `optional`.
