### PR TITLE
Upgrade ekuiper to 1.4.3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,7 +66,7 @@ parts:
 
   kuiper:
     source: https://github.com/lf-edge/ekuiper.git
-    source-tag: 1.4.2
+    source-tag: 1.4.3
     source-depth: 1
     plugin: make
     build-packages: [gcc, git, libczmq-dev, pkg-config, zip]


### PR DESCRIPTION
1.4.3 version resolves stream's topic subscription issue

Signed-off-by: Mengyi Wang mengyi.wang@canonical.com

## Testing Instructions
1. Install and setup edgexfoundry and edgex-ekuiper:
```
snap install edgexfoundry --edge
```
```
snapcraft
snap install edgex-ekuiper_1.4.2+snap.3-dirty_amd64.snap --devmode
```
```
snap connect edgexfoundry:edgex-secretstore-token edgex-ekuiper:edgex-secretstore-token
snap restart edgex-ekuiper
snap set edgexfoundry device-virtual=on
snap set edgexfoundry app-service-configurable=on
```
2. Create a stream (with SHARED=false) and multiple rules using this same stream:
```
# stream 1
edgexfoundry.kuiper-cli create stream stream1 '()WITH(FORMAT="JSON",TYPE="edgex",SHARED="false")'

# rule 1 
edgex-ekuiper.kuiper-cli create rule rule_log '
{
   "sql":"SELECT * from stream1",
   "actions":[
      {
         "log":{
            
         }
      }
   ]
}' 

# rules 2
edgex-ekuiper.kuiper-cli create rule rule_edgex_message_bus '
{
   "sql":"SELECT * from stream1",
   "actions": [
      {
         "edgex": {
            "connectionSelector": "edgex.redisMsgBus",
            "topicPrefix": "edgex/events/device", 
            "messageType": "request",
            "deviceName": "device-test"
         }
      }
   ]
}'

```
3. Check rules's status:
```
edgex-ekuiper.kuiper-cli show rules
```
```
Connecting to 127.0.0.1:20498... 
[
  {
    "id": "rule_edgex_message_bus",
    "status": "Running"
  },
  {
    "id": "rule_log",
    "status": "Running"
  }
]
```
4. Wait about 10 minutes and re-check the rules' status:
```
edgexfoundry.kuiper-cli show rules
```
Expect:
```
Connecting to 127.0.0.1:20498... 
[
  {
    "id": "rule_edgex_message_bus",
    "status": "Running"
  },
  {
    "id": "rule_log",
    "status": "Running"
  }
]
```

