### PR TITLE
Fix tagging regex to accept semver build metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Validate version
         run: |
-          # Check if tag is X.Y.Z-snap or X.Y.Z-snap.N; N > 1
-          if [[ ! "${{ github.event.inputs.tag_name }}" =~ ^[0-9]+.[0-9]+.[0-9]+-snap(.[2-9]|.[1-9][0-9]+)?$ ]]
+          # Check if tag is X.Y.Z+snap or X.Y.Z+snap.N; N > 1
+          if [[ ! "${{ github.event.inputs.tag_name }}" =~ ^[0-9]+.[0-9]+.[0-9]+\+snap(.[2-9]|.[1-9][0-9]+)?$ ]]
           then
             echo "Invalid version!"
             exit 1


### PR DESCRIPTION
This makes the tagging inline with the spec: https://github.com/canonical/edgex-ekuiper-snap#tagging

The tagging workflow uses the semver pre-release format by mistake.
