### PR TITLE
Update incompatible changes in kuiper.yaml, upgrade version to 1.6.3

### DIFF
--- a/etc/kuiper.yaml
+++ b/etc/kuiper.yaml
@@ -58,17 +58,33 @@ rule:
   sendError: true
 
 sink:
-  # The cache persistence threshold size. If the message in sink cache is larger than 10, then it triggers persistence. If you find
-  # the remote system is slow to response, or sink throughput is small, then it's recommend to increase below 2 configurations.
-  # More memory is required with the increase of below 2 configurations.
-  # If the message count reaches below value, then it triggers persistence.
-  cacheThreshold: 10
-  # The message persistence is triggered by a ticker, and cacheTriggerCount is for using configure the count to trigger the persistence procedure
-  # regardless if the message number reaches cacheThreshold or not. This is to prevent the data won't be saved as the cache never pass the threshold.
-  cacheTriggerCount: 15
+  # Control to enable cache or not. If it's set to true, then the cache will be enabled, otherwise, it will be disabled.
+  enableCache: false
 
-  # Control to disable cache or not. If it's set to true, then the cache will be disabled, otherwise, it will be enabled.
-  disableCache: true
+  # The maximum number of messages to be cached in memory.
+  memoryCacheThreshold: 1024
+
+  # The maximum number of messages to be cached in the disk.
+  maxDiskCache: 1024000
+
+  # The number of messages for a buffer page which is the unit to read/write to disk in batch to prevent frequent IO
+  bufferPageSize: 256
+
+  # The interval in millisecond to resend the cached messages
+  resendInterval: 0
+
+  # Whether to clean the cache when the rule stops
+  cleanCacheAtStop: false
+
+source:
+  ## Configurations for the global http data server for httppush source
+  # HTTP data service ip
+  httpServerIp: 0.0.0.0
+  # HTTP data service port
+  httpServerPort: 10081
+  # httpServerTls:
+  #    certfile: /var/https-server.crt
+  #    keyfile: /var/https-server.key
 
 store:
   #Type of store that will be used for keeping state of the application

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
   kuiper:
     source: https://github.com/lf-edge/ekuiper.git
-    source-tag: 1.6.0
+    source-tag: 1.6.3
     source-depth: 1
     plugin: make
     build-packages: [gcc, git, libczmq-dev, pkg-config, zip]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
 
   kuiper:
     source: https://github.com/lf-edge/ekuiper.git
-    source-tag: 1.5.1
+    source-tag: 1.6.0
     source-depth: 1
     plugin: make
     build-packages: [gcc, git, libczmq-dev, pkg-config, zip]


### PR DESCRIPTION
This PR replaced some fields with new fields from etc/kuiper.yaml: cacheThreshold, cacheTriggerCount, disableCache.

Please see [ekuiper 1.6.0 release note](https://github.com/lf-edge/ekuiper/releases/tag/1.6.0)