### PR TITLE
Correct ASC subscription instruction text

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ snap set edgex-app-service-configurable profile=rules-engine
 snap start edgex-app-service-configurable
 ````
 Then, set eKuiper to subscribe to `app-service-configurable` by changing the 
-default topic to `rules-event` and default messageType to `event`:
+edgex default topic to `rules-event` and messageType to `event`:
 ```bash
 snap set edgex-ekuiper config.edgex.default.topic=rules-events config.edgex.default.messagetype=event
 # restart is required to load new configuration options

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ snap install edgex-app-service-configurable
 snap set edgex-app-service-configurable profile=rules-engine
 snap start edgex-app-service-configurable
 ````
-Then, set eKuiper to subscribe to `app-service-configurable` by changing ekuiper's 
-default topic from 'rules-event' to 'edgex/events/#', default messageType from 'event' to 'request':
+Then, set eKuiper to subscribe to `app-service-configurable` by changing the 
+default topic to `rules-event` and default messageType to `event`:
 ```bash
 snap set edgex-ekuiper config.edgex.default.topic=rules-events config.edgex.default.messagetype=event
 # restart is required to load new configuration options


### PR DESCRIPTION
The text explains switching to raw events which is opposite of what is expected. This PR corrects that.