### PR TITLE
Upgrade to eKuiper 1.7.3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,11 +37,6 @@ slots:
       write: 
         - $SNAP_DATA/edgex-ekuiper
 
-plugs:
-  ekuiper-ruleset:
-    interface: content
-    target: $SNAP_DATA/data
-
 apps:
   kuiper:
     command: bin/kuiperd
@@ -85,13 +80,13 @@ parts:
 
   kuiper:
     source: https://github.com/lf-edge/ekuiper.git
-    source-tag: 1.7.0
+    source-tag: 1.7.3
     source-depth: 1
     plugin: make
     build-packages: [gcc, git, libczmq-dev, pkg-config, zip]
     stage-packages: [libzmq5]
     build-snaps:
-      - go/1.17/stable
+      - go/1.18/stable
     override-build: |
       cd $SNAPCRAFT_PART_SRC
       

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,11 @@ slots:
       write: 
         - $SNAP_DATA/edgex-ekuiper
 
+plugs:
+  ekuiper-ruleset:
+    interface: content
+    target: $SNAP_DATA/data
+
 apps:
   kuiper:
     command: bin/kuiperd
@@ -80,7 +85,7 @@ parts:
 
   kuiper:
     source: https://github.com/lf-edge/ekuiper.git
-    source-tag: 1.6.3
+    source-tag: 1.7.0
     source-depth: 1
     plugin: make
     build-packages: [gcc, git, libczmq-dev, pkg-config, zip]


### PR DESCRIPTION
1. Install edgex-ekuiper and import ruleset as `init.json`:
```
snap install edgex-ekuiper_1.4.2+snap.3+git28.2b0705a-dirty_amd64.snap --dangerous
```
```
sudo nano /var/snap/edgex-ekuiper/current/data/init.json
```
add:
```
{
  "streams": {
    "test-stream": "CREATE STREAM test-stream () WITH (DATASOURCE=\"users\", FORMAT=\"JSON\")"
  },
  "tables": {},
  "rules": {
    "rule1": "{\"id\": \"rule1\",\"sql\": \"SELECT * FROM test-stream\",\"actions\": [{\"log\": {}}]}",
    "rule2": "{\"id\": \"rule2\",\"sql\": \"SELECT * FROM test-stream\",\"actions\": [{  \"log\": {}}]}"
  }
}
```
2. Validate streams and rules set by the above ruleset
```
sudo snap set edgex-ekuiper config.edgex-security-secret-store=false
sudo snap start edgex-ekuiper.kuiper
edgex-ekuiper.kuiper-cli show streams
...
test-stream
```
```
edgex-ekuiper.kuiper-cli show rules
...
[
  {
    "id": "rule1",
    "name": "rule1",
    "status": "Stopped: canceled manually or by error."
  },
  {
    "id": "rule2",
    "name": "rule2",
    "status": "Stopped: canceled manually or by error."
  }
]
```



