### PR TITLE
Rename eKuiper daemon and client apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Verify that by executing the following command:
 ```bash
 $ sudo snap services edgex-ekuiper edgexfoundry
 Service                                                  Startup   Current   Notes
-edgex-ekuiper.kuiper                                     disabled  inactive    -
+edgex-ekuiper.kuiperd                                    disabled  inactive    -
 edgexfoundry.app-service-configurable                    disabled  inactive  -
 edgexfoundry.consul                                      enabled   active    -
 edgexfoundry.core-command                                enabled   active    -
@@ -102,17 +102,17 @@ The service can be started as follows.
 The `--enable` option ensures that as well as starting the service now, 
 it will be automatically started on boot:
 ```bash
-sudo snap start --enable edgex-ekuiper.kuiperd
+sudo snap start --enable edgex-ekuiper
 ```
 
 Conversely, the service can be stopped and disabled as follows:
 ```bash
-sudo snap stop --disable edgex-ekuiper.kuiperd
+sudo snap stop --disable edgex-ekuiper
 ```
 
 To restart a running instance and load new configurations:
 ```bash
-sudo snap restart edgex-ekuiper.kuiperd
+sudo snap restart edgex-ekuiper
 ```
 
 ### Configuration files

--- a/README.md
+++ b/README.md
@@ -102,17 +102,17 @@ The service can be started as follows.
 The `--enable` option ensures that as well as starting the service now, 
 it will be automatically started on boot:
 ```bash
-sudo snap start --enable edgex-ekuiper.kuiper
+sudo snap start --enable edgex-ekuiper.kuiperd
 ```
 
 Conversely, the service can be stopped and disabled as follows:
 ```bash
-sudo snap stop --disable edgex-ekuiper.kuiper
+sudo snap stop --disable edgex-ekuiper.kuiperd
 ```
 
 To restart a running instance and load new configurations:
 ```bash
-sudo snap restart edgex-ekuiper.kuiper
+sudo snap restart edgex-ekuiper.kuiperd
 ```
 
 ### Configuration files

--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -22,7 +22,7 @@ import (
 )
 
 func configure() {
-	const app = "kuiper"
+	const app = "kuiperd"
 
 	log.SetComponentName("configure")
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,7 +43,7 @@ plugs:
     target: $SNAP_DATA # the provider needs to supply files under $SNAP_DATA/data
 
 apps:
-  kuiper:
+  kuiperd:
     command: bin/kuiperd
     command-chain:
       - bin/source-env-file.sh
@@ -58,6 +58,13 @@ apps:
     restart-delay: 3s
     plugs: [network, network-bind]
 
+  kuiper:
+    command: bin/kuiper
+    environment:
+      KuiperBaseKey: $SNAP_DATA
+    plugs: [home, network, network-bind]
+
+  # deprecated
   kuiper-cli:
     command: bin/kuiper
     environment:


### PR DESCRIPTION
This PR renames eKuiper daemon from `kuiper` to `kuiperd`, and adds a new app called `kuiper` which launches the eKuiper client. In order not to break backward compatibility, the existing "kuiper-cli" app is still here and marked as deprecated.

The new naming is to add consistency with the upstream naming of eKuiper applications, i.e. `kuiperd` for the daemon and `kuiper` for the client.

Along with these changes, the following testing and documentation need to be updated:
- [x] snap testing: https://github.com/canonical/edgex-snap-testing/pull/151
- [ ] edgex demo: https://github.com/canonical/edgex-demos/pull/19