### PR TITLE
Update service name in source-env-file

### DIFF
--- a/snap/local/bin/source-env-file.sh
+++ b/snap/local/bin/source-env-file.sh
@@ -2,7 +2,7 @@
 
 SERVICE="kuiperd"
 SERVICE_ENV="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
-TAG="edgex-$SERVICE."$(basename "$0")
+TAG="$SNAP_INSTANCE_NAME."$(basename "$0")
 
 if [ -f "$SERVICE_ENV" ]; then
     logger --tag=$TAG "Sourcing $SERVICE_ENV"

--- a/snap/local/bin/source-env-file.sh
+++ b/snap/local/bin/source-env-file.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-SERVICE="kuiper"
+SERVICE="kuiperd"
 SERVICE_ENV="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
 TAG="edgex-$SERVICE."$(basename "$0")
 


### PR DESCRIPTION
This PR updates the daemon service name to `kuiperd`. The daemon service name of edgex-ekuiper has been updated from `kuiper` to `kuiperd` by PR #46.
