### PR TITLE
fix(snap): Refactor to avoid conflicts with readonly config provider directory

### DIFF
--- a/snap/local/bin/source-env-file.sh
+++ b/snap/local/bin/source-env-file.sh
@@ -1,7 +1,7 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 SERVICE="kuiperd"
-ENV_FILE="$SNAP_DATA/config/$SERVICE/res/overrides.env"
+ENV_FILE="$SNAP_DATA/config/$SERVICE/overrides.env"
 TAG="$SNAP_INSTANCE_NAME."$(basename "$0")
 
 if [ -f "$ENV_FILE" ]; then

--- a/snap/local/bin/source-env-file.sh
+++ b/snap/local/bin/source-env-file.sh
@@ -1,13 +1,13 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 SERVICE="kuiperd"
-SERVICE_ENV="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
+ENV_FILE="$SNAP_DATA/config/$SERVICE/res/overrides.env"
 TAG="$SNAP_INSTANCE_NAME."$(basename "$0")
 
-if [ -f "$SERVICE_ENV" ]; then
-    logger --tag=$TAG "Sourcing $SERVICE_ENV"
+if [ -f "$ENV_FILE" ]; then
+    logger --tag=$TAG "Sourcing $ENV_FILE"
     set -o allexport
-    source "$SERVICE_ENV" set
+    source "$ENV_FILE" set
     set +o allexport
 fi
 

--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -22,8 +22,6 @@ import (
 )
 
 func configure() {
-	const app = "kuiperd"
-
 	log.SetComponentName("configure")
 
 	options.EnableConfigHierarchy()

--- a/snap/local/helper-go/configure.go
+++ b/snap/local/helper-go/configure.go
@@ -21,6 +21,8 @@ import (
 	"github.com/canonical/edgex-snap-hooks/v3/options"
 )
 
+const daemonApp = "kuiperd"
+
 func configure() {
 	log.SetComponentName("configure")
 
@@ -28,11 +30,11 @@ func configure() {
 	options.SetHierarchySeparator("__")
 	options.SetSegmentSeparator("_")
 
-	if err := options.ProcessConfig(app); err != nil {
+	if err := options.ProcessConfig(daemonApp); err != nil {
 		log.Fatalf("Error processing config options: %v", err)
 	}
 
-	if err := options.ProcessAutostart(app); err != nil {
+	if err := options.ProcessAutostart(daemonApp); err != nil {
 		log.Fatalf("Error processing autostart options: %v", err)
 	}
 }

--- a/snap/local/helper-go/go.mod
+++ b/snap/local/helper-go/go.mod
@@ -2,4 +2,4 @@ module github.com/canonical/edgex-ekuiper-snap/snap/local/helper-go
 
 go 1.18
 
-require github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230112170125-c0580fb68dab
+require github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230315153603-544c6823a1b0

--- a/snap/local/helper-go/go.sum
+++ b/snap/local/helper-go/go.sum
@@ -1,5 +1,7 @@
 github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230112170125-c0580fb68dab h1:wpiKN0hX8tqeZNa4jPvgyrqP8ixm1Xu7lcQA3bypR7w=
 github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230112170125-c0580fb68dab/go.mod h1:RvJ48YbdBPZn7L8OcylOpKIlIJD+nMjo5D7WSnPYusY=
+github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230315153603-544c6823a1b0 h1:h2C5W3mEC5g/s9W/mwh7X/3uSqKjNln/xHP41i8Mw/M=
+github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230315153603-544c6823a1b0/go.mod h1:qGZwprCZGZk2pA9BrleUtSrGrfHIaIz1356p8aqzuN4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=

--- a/snap/local/helper-go/install.go
+++ b/snap/local/helper-go/install.go
@@ -41,7 +41,7 @@ func install() {
 	log.SetComponentName("install")
 
 	// Install default config files only if no config provider is connected
-	isConnected, err := snapctl.IsConnected(app + "-config").Run()
+	isConnected, err := snapctl.IsConnected("ekuiper-data").Run()
 	if err != nil {
 		log.Fatalf("Error checking interface connection: %s", err)
 	}

--- a/snap/local/helper-go/install.go
+++ b/snap/local/helper-go/install.go
@@ -20,6 +20,7 @@ import (
 	hooks "github.com/canonical/edgex-snap-hooks/v3"
 	"github.com/canonical/edgex-snap-hooks/v3/env"
 	"github.com/canonical/edgex-snap-hooks/v3/log"
+	"github.com/canonical/edgex-snap-hooks/v3/snapctl"
 )
 
 // installConfig copies all config files from $SNAP to $SNAP_DATA.
@@ -39,7 +40,14 @@ func installConfig() error {
 func install() {
 	log.SetComponentName("install")
 
-	if err := installConfig(); err != nil {
-		log.Fatalf("Error installing config files: %s", err)
+	// Install default config files only if no config provider is connected
+	isConnected, err := snapctl.IsConnected(app + "-config").Run()
+	if err != nil {
+		log.Fatalf("Error checking interface connection: %s", err)
+	}
+	if !isConnected {
+		if err := installConfig(); err != nil {
+			log.Fatalf("Error installing config files: %s", err)
+		}
 	}
 }

--- a/snap/local/helper-go/main.go
+++ b/snap/local/helper-go/main.go
@@ -19,8 +19,6 @@ import (
 	"os"
 )
 
-const app = "kuiperd"
-
 func main() {
 	subCommand := os.Args[1]
 	switch subCommand {

--- a/snap/local/helper-go/main.go
+++ b/snap/local/helper-go/main.go
@@ -19,6 +19,8 @@ import (
 	"os"
 )
 
+const app = "kuiperd"
+
 func main() {
 	subCommand := os.Args[1]
 	switch subCommand {


### PR DESCRIPTION
Changes to incorporate the following fixes:
- https://github.com/canonical/edgex-snap-hooks/pull/83
- https://github.com/canonical/edgex-snap-hooks/pull/82

For testing instructions, please refer to https://github.com/edgexfoundry/device-mqtt-go/pull/535